### PR TITLE
fix rake opal:rspec:server

### DIFF
--- a/lib/opal/rspec/rails/server.rb
+++ b/lib/opal/rspec/rails/server.rb
@@ -19,11 +19,14 @@ class Opal::RSpec::Rails::Server < ::Opal::Server
 
     app    = Rails.application
     assets = app.config.opal_rspec.sprockets_instance || app.assets
+    spec_location = Rails.root.join(app.config.opal_rspec.spec_location).to_s
+
     assets.append_path Opal::RSpec::Rails.root.join('opal').to_s
-    assets.append_path Rails.root.join(app.config.opal_rspec.spec_location).to_s
+    assets.append_path spec_location
 
     super(options.merge(sprockets: assets)) do |server|
       server.main = 'opal-rspec-rails-runner'
+      server.append_path spec_location
     end
   end
 

--- a/lib/opal/rspec/rails/task.rb
+++ b/lib/opal/rspec/rails/task.rb
@@ -58,7 +58,7 @@ class Task < Rake::SprocketsTask
   attr_writer :cache_path
 
   def server
-    @server ||= ::Opal::RSpec::Rails::Server.new(prefix: '/')
+    @server ||= ::Opal::RSpec::Rails::Server.new
   end
 
   def port

--- a/opal-rspec-rails.gemspec
+++ b/opal-rspec-rails.gemspec
@@ -27,9 +27,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'opal',       '~> 0.9.2'
-  spec.add_dependency 'opal-rspec', '~> 0.5.0'
-  spec.add_dependency 'opal-rails', '~> 0.9.0.dev'
+  spec.add_dependency 'opal',       ['>= 0.10.0', '< 0.11']
+  spec.add_dependency 'opal-rspec'
+  spec.add_dependency 'opal-rails'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
- fix javascript script tag:
  remove prefix from :Opal::RSpec::Rails::Server which causes a double slash in the javascript script tag
- fix config.opal_rspec.spec_location to load both sprocket assets as well as the Opal::Server so
  opal-rspec-rails-runner sees the spec files
